### PR TITLE
Add activity-level attributes to iati object

### DIFF
--- a/solr/activity/flattener.js
+++ b/solr/activity/flattener.js
@@ -122,6 +122,17 @@ module.exports = {
                 }
             }
 
+            for (let i = 0; i < node.attributes.length; i += 1) {
+                const att = node.attributes[i];
+
+                const canonicalAttName = module.exports.convertNameToCanonical(
+                    att.nodeName,
+                    canonicalName
+                );
+
+                module.exports.addToIatiObject(canonicalAttName, att.nodeValue);
+            }
+
             for (let i = 0; i < node.childNodes.length; i += 1) {
                 module.exports.buildIatiObject(node.childNodes[i], canonicalName, false);
             }


### PR DESCRIPTION
Attributes were only being extracted below the iati-activity level, so this should be a quick fix. All the new columns are already in the SOLR schema so no need to edit that file:

![image](https://user-images.githubusercontent.com/2836840/124786584-d4a7b500-df15-11eb-8b3f-ba5aff56096c.png)
